### PR TITLE
Update pie-register.php

### DIFF
--- a/pie-register.php
+++ b/pie-register.php
@@ -611,6 +611,9 @@ if( !class_exists('PieRegister') ){
 					array_push($form_ids, 'reg_form_'.$option['Id']);
 					$fields_data 	= maybe_unserialize(get_option("piereg_form_fields_".$option['Id']));
 					$the_cap_field = "captcha";
+					if(!$fields_data) {
+						continue;
+					}
 					$fields_data_filtered = array_filter($fields_data, function($el) use ($the_cap_field) {
 						return ( $el['type'] == $the_cap_field );
 					});


### PR DESCRIPTION
When `fields_data` is `false`, or null, there is an Warning.
`Warning: array_filter() expects parameter 1 to be array, boolean given in /XXX/XXX/YYY/wp-content/plugins/pie-register/pie-register.php on line 694 (694 is the line of the current plugin version 3.4.5`.